### PR TITLE
AttrTarget demo

### DIFF
--- a/compiler/rustc_ast_lowering/src/block.rs
+++ b/compiler/rustc_ast_lowering/src/block.rs
@@ -1,4 +1,5 @@
 use rustc_ast::{Block, BlockCheckMode, Local, LocalKind, Stmt, StmtKind};
+use rustc_attr_parsing::AttrTarget;
 use rustc_hir as hir;
 use rustc_span::sym;
 use smallvec::SmallVec;
@@ -109,7 +110,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         };
         let span = self.lower_span(l.span);
         let source = hir::LocalSource::Normal;
-        self.lower_attrs(hir_id, &l.attrs, l.span);
+        self.lower_attrs(hir_id, &l.attrs, AttrTarget::Todo, l.span);
         self.arena.alloc(hir::LetStmt { hir_id, super_, ty, pat, init, els, span, source })
     }
 

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -42,7 +42,7 @@ use std::sync::Arc;
 
 use rustc_ast::node_id::NodeMap;
 use rustc_ast::{self as ast, *};
-use rustc_attr_parsing::{AttributeParser, OmitDoc};
+use rustc_attr_parsing::{AttrTarget, AttributeParser, OmitDoc};
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::sorted_map::SortedMap;
 use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
@@ -911,12 +911,14 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         &mut self,
         id: HirId,
         attrs: &[Attribute],
+        target: AttrTarget<'_>,
         target_span: Span,
     ) -> &'hir [hir::Attribute] {
         if attrs.is_empty() {
             &[]
         } else {
-            let lowered_attrs = self.lower_attrs_vec(attrs, self.lower_span(target_span), id);
+            let lowered_attrs =
+                self.lower_attrs_vec(attrs, target, self.lower_span(target_span), id);
 
             assert_eq!(id.owner, self.current_hir_id_owner);
             let ret = self.arena.alloc_from_iter(lowered_attrs);
@@ -939,12 +941,14 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     fn lower_attrs_vec(
         &mut self,
         attrs: &[Attribute],
+        target: AttrTarget<'_>,
         target_span: Span,
         target_hir_id: HirId,
     ) -> Vec<hir::Attribute> {
         let l = self.span_lowerer();
         self.attribute_parser.parse_attribute_list(
             attrs,
+            target,
             target_span,
             target_hir_id,
             OmitDoc::Lower,
@@ -1899,7 +1903,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         let (name, kind) = self.lower_generic_param_kind(param, source);
 
         let hir_id = self.lower_node_id(param.id);
-        self.lower_attrs(hir_id, &param.attrs, param.span());
+        self.lower_attrs(hir_id, &param.attrs, AttrTarget::Todo, param.span());
         hir::GenericParam {
             hir_id,
             def_id: self.local_def_id(param.id),

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use rustc_ast::ptr::P;
 use rustc_ast::*;
+use rustc_attr_parsing::AttrTarget;
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::{self as hir, LangItem};
@@ -94,7 +95,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
 
                         let fs = self.arena.alloc_from_iter(fields.iter().map(|f| {
                             let hir_id = self.lower_node_id(f.id);
-                            self.lower_attrs(hir_id, &f.attrs, f.span);
+                            self.lower_attrs(hir_id, &f.attrs, AttrTarget::Todo, f.span);
 
                             hir::PatField {
                                 hir_id,

--- a/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/deprecation.rs
@@ -45,6 +45,7 @@ impl<S: Stage> SingleAttributeParser<S> for DeprecationParser {
     const PATH: &[Symbol] = &[sym::deprecated];
     const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepFirst;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const POSITIONS: &[crate::TargetChecker] = &[crate::allowed!(_)];
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
         let features = cx.features();

--- a/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
@@ -1,6 +1,7 @@
 use rustc_attr_data_structures::AttributeKind;
 use rustc_span::{Symbol, sym};
 
+use crate::AttrTarget;
 use crate::attributes::{AttributeOrder, OnDuplicate, SingleAttributeParser};
 use crate::context::{AcceptContext, Stage};
 use crate::parser::ArgParser;
@@ -15,6 +16,10 @@ impl<S: Stage> SingleAttributeParser<S> for AsPtrParser {
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, _args: &ArgParser<'_>) -> Option<AttributeKind> {
+        if !matches!(cx.target, AttrTarget::Function { .. } | AttrTarget::Method { .. }) {
+            cx.dcx().span_err(cx.attr_span, "rustc_as_ptr must be applied to a function or method (rejected during attr parsing)");
+            return None;
+        }
         // FIXME: check that there's no args (this is currently checked elsewhere)
         Some(AttributeKind::AsPtr(cx.attr_span))
     }

--- a/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/lint_helpers.rs
@@ -1,7 +1,6 @@
 use rustc_attr_data_structures::AttributeKind;
 use rustc_span::{Symbol, sym};
 
-use crate::AttrTarget;
 use crate::attributes::{AttributeOrder, OnDuplicate, SingleAttributeParser};
 use crate::context::{AcceptContext, Stage};
 use crate::parser::ArgParser;
@@ -14,12 +13,9 @@ impl<S: Stage> SingleAttributeParser<S> for AsPtrParser {
     const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepFirst;
 
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Error;
+    const POSITIONS: &[crate::TargetChecker] = &[crate::allowed!(Function | Method)];
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, _args: &ArgParser<'_>) -> Option<AttributeKind> {
-        if !matches!(cx.target, AttrTarget::Function { .. } | AttrTarget::Method { .. }) {
-            cx.dcx().span_err(cx.attr_span, "rustc_as_ptr must be applied to a function or method (rejected during attr parsing)");
-            return None;
-        }
         // FIXME: check that there's no args (this is currently checked elsewhere)
         Some(AttributeKind::AsPtr(cx.attr_span))
     }

--- a/compiler/rustc_attr_parsing/src/attributes/stability.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/stability.rs
@@ -9,6 +9,7 @@ use rustc_span::{Span, Symbol, sym};
 
 use super::util::parse_version;
 use super::{AcceptMapping, AttributeOrder, AttributeParser, OnDuplicate, SingleAttributeParser};
+use crate::allowed;
 use crate::context::{AcceptContext, FinalizeContext, Stage};
 use crate::parser::{ArgParser, MetaItemParser};
 use crate::session_diagnostics::{self, UnsupportedLiteralReason};
@@ -120,6 +121,7 @@ impl<S: Stage> SingleAttributeParser<S> for ConstStabilityIndirectParser {
     const PATH: &[Symbol] = &[sym::rustc_const_stable_indirect];
     const ATTRIBUTE_ORDER: AttributeOrder = AttributeOrder::KeepFirst;
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Ignore;
+    const POSITIONS: &[crate::TargetChecker] = &[allowed!(_)];
 
     fn convert(_cx: &mut AcceptContext<'_, '_, S>, _args: &ArgParser<'_>) -> Option<AttributeKind> {
         Some(AttributeKind::ConstStabilityIndirect)

--- a/compiler/rustc_attr_parsing/src/attributes/transparency.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/transparency.rs
@@ -3,9 +3,9 @@ use rustc_span::hygiene::Transparency;
 use rustc_span::{Symbol, sym};
 
 use super::{AttributeOrder, OnDuplicate, SingleAttributeParser};
+use crate::allowed;
 use crate::context::{AcceptContext, Stage};
 use crate::parser::ArgParser;
-
 pub(crate) struct TransparencyParser;
 
 // FIXME(jdonszelmann): make these proper diagnostics
@@ -17,6 +17,7 @@ impl<S: Stage> SingleAttributeParser<S> for TransparencyParser {
     const ON_DUPLICATE: OnDuplicate<S> = OnDuplicate::Custom(|cx, used, unused| {
         cx.dcx().span_err(vec![used, unused], "multiple macro transparency attributes");
     });
+    const POSITIONS: &[crate::TargetChecker] = &[allowed!(_)];
 
     fn convert(cx: &mut AcceptContext<'_, '_, S>, args: &ArgParser<'_>) -> Option<AttributeKind> {
         match args.name_value().and_then(|nv| nv.value_as_str()) {

--- a/compiler/rustc_attr_parsing/src/attributes/util.rs
+++ b/compiler/rustc_attr_parsing/src/attributes/util.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use rustc_ast::attr::{AttributeExt, first_attr_value_str_by_name};
 use rustc_attr_data_structures::RustcVersion;
 use rustc_feature::is_builtin_attr_name;
@@ -55,4 +57,26 @@ pub fn is_doc_alias_attrs_contain_symbol<'tcx, T: AttributeExt + 'tcx>(
         }
     }
     false
+}
+
+pub(crate) struct PathPrinter<'s>(pub &'s [Symbol]);
+
+impl fmt::Display for PathPrinter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "#[")?;
+        match &self.0 {
+            &[] => {}
+            &[one] => {
+                write!(f, "{one}")?;
+            }
+            &[start @ .., last] => {
+                for segment in start {
+                    write!(f, "{segment}::")?;
+                }
+                write!(f, "{last}")?;
+            }
+        }
+        write!(f, "]")?;
+        Ok(())
+    }
 }

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -89,6 +89,7 @@ pub(crate) mod context;
 mod lints;
 pub mod parser;
 mod session_diagnostics;
+#[macro_use]
 mod target;
 
 pub use attributes::cfg::*;
@@ -97,6 +98,6 @@ pub use attributes::util::{
 };
 pub use context::{AttributeParser, Early, Late, OmitDoc};
 pub use lints::emit_attribute_lint;
-pub use target::AttrTarget;
+pub use target::*;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }

--- a/compiler/rustc_attr_parsing/src/lib.rs
+++ b/compiler/rustc_attr_parsing/src/lib.rs
@@ -89,6 +89,7 @@ pub(crate) mod context;
 mod lints;
 pub mod parser;
 mod session_diagnostics;
+mod target;
 
 pub use attributes::cfg::*;
 pub use attributes::util::{
@@ -96,5 +97,6 @@ pub use attributes::util::{
 };
 pub use context::{AttributeParser, Early, Late, OmitDoc};
 pub use lints::emit_attribute_lint;
+pub use target::AttrTarget;
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }

--- a/compiler/rustc_attr_parsing/src/target.rs
+++ b/compiler/rustc_attr_parsing/src/target.rs
@@ -1,4 +1,6 @@
 use rustc_ast as ast;
+use rustc_span::{DUMMY_SP, Ident};
+use thin_vec::ThinVec;
 
 /// Enumeration of things that an attribute can be on.
 #[derive(Copy, Clone, Debug)]
@@ -19,6 +21,64 @@ pub enum AttrTarget<'ast> {
 
     // everything else
     Todo,
+}
+
+impl AttrTarget<'_> {
+    pub fn allowed(checks: &[TargetChecker]) -> Vec<&'static str> {
+        // This is kinda ugly but we need a default value of the ast type to see if the check would
+        // succeed. The contents don't need to make sense since the `allowed!` macro forces that it
+        // cannot be matched on by fields.
+        //
+        // Things to make this nicer would be:
+        // - Implement Default for everything,
+        // - use the `strum` crate to generate a fieldless version of AttrTarget
+        // - Maybe some way to get discriminants of enums without needing to instantiate it
+        // - Some sort of unsafe hax maybe
+        let generics = ast::Generics::default();
+        let fn_sig = ast::FnSig {
+            header: ast::FnHeader::default(),
+            decl: Box::new(ast::FnDecl {
+                inputs: ThinVec::new(),
+                output: ast::FnRetTy::Default(DUMMY_SP),
+            }),
+            span: DUMMY_SP,
+        };
+        let function = &ast::Fn {
+            defaultness: ast::Defaultness::Final,
+            ident: Ident::dummy(),
+            sig: fn_sig,
+            generics: generics.clone(),
+            contract: None,
+            body: None,
+            define_opaque: None,
+        };
+        let trait_ = &ast::Trait {
+            safety: ast::Safety::Default,
+            is_auto: ast::IsAuto::No,
+            ident: Ident::dummy(),
+            generics,
+            bounds: Vec::new(),
+            items: ThinVec::new(),
+        };
+
+        // BTreeSet to handle the case with overlapping 
+        let mut ret = std::collections::BTreeSet::new();
+        for c in checks {
+            for check in c.check {
+                if check(AttrTarget::Function { function }) {
+                    ret.insert("function");
+                }
+                if check(AttrTarget::Method { function }) {
+                    ret.insert("method");
+                }
+                if check(AttrTarget::Trait { trait_ }) {
+                    ret.insert("trait");
+                }
+            }
+        }
+
+        ret.into_iter().collect()
+    }
 }
 
 impl<'ast> From<&'ast ast::ItemKind> for AttrTarget<'ast> {
@@ -43,4 +103,41 @@ impl<'ast> From<(bool, &'ast ast::AssocItemKind)> for AttrTarget<'ast> {
             _ => AttrTarget::Todo,
         }
     }
+}
+
+#[macro_export]
+macro_rules! allowed {
+    (_) => {{
+        $crate::TargetChecker {
+            check: &[
+                {
+                    fn check(_: $crate::AttrTarget<'_>) -> bool {
+                        true
+                    }
+                    check
+                }
+            ],
+        }
+    }};
+    ($($variant:ident)|*) => {{
+        $crate::TargetChecker {
+            check: &[
+                $({
+                    fn check(target: $crate::AttrTarget<'_>) -> bool {
+                        matches!(target, | $crate::AttrTarget::$variant { .. } )
+                    }
+                    check
+                }),*
+            ],
+        }
+    }};
+}
+
+pub struct TargetChecker {
+    pub check: &'static [fn(crate::AttrTarget<'_>) -> bool],
+}
+
+pub struct PosError {
+    pub accepted: Vec<&'static str>,
+    pub found_on: &'static str,
 }

--- a/compiler/rustc_attr_parsing/src/target.rs
+++ b/compiler/rustc_attr_parsing/src/target.rs
@@ -1,0 +1,46 @@
+use rustc_ast as ast;
+
+/// Enumeration of things that an attribute can be on.
+#[derive(Copy, Clone, Debug)]
+pub enum AttrTarget<'ast> {
+    Function {
+        function: &'ast ast::Fn,
+    },
+    // Probably should have two variants for trait methods and regular impl methods
+    Method {
+        function: &'ast ast::Fn,
+    },
+
+    Trait {
+        // This would be nice for `#[diagnostic::_]` parsing,
+        // where we'd like to look at the generics.
+        trait_: &'ast ast::Trait,
+    },
+
+    // everything else
+    Todo,
+}
+
+impl<'ast> From<&'ast ast::ItemKind> for AttrTarget<'ast> {
+    fn from(kind: &'ast ast::ItemKind) -> Self {
+        use ast::ItemKind::*;
+
+        match kind {
+            Fn(f) => AttrTarget::Function { function: &**f },
+            Trait(t) => AttrTarget::Trait { trait_: &**t },
+            _ => AttrTarget::Todo,
+        }
+    }
+}
+
+// FIXME(bool_hater) maybe _is_in_trait_impl should really be an enum, not a bool
+impl<'ast> From<(bool, &'ast ast::AssocItemKind)> for AttrTarget<'ast> {
+    fn from((_is_in_trait_impl, assoc): (bool, &'ast ast::AssocItemKind)) -> Self {
+        use ast::AssocItemKind::*;
+
+        match assoc {
+            Fn(f) => AttrTarget::Method { function: &**f },
+            _ => AttrTarget::Todo,
+        }
+    }
+}

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -186,7 +186,7 @@ use rustc_ast::{
     Generics, Mutability, PatKind, VariantData,
 };
 use rustc_attr_data_structures::{AttributeKind, ReprPacked};
-use rustc_attr_parsing::AttributeParser;
+use rustc_attr_parsing::{AttrTarget, AttributeParser};
 use rustc_expand::base::{Annotatable, ExtCtxt};
 use rustc_hir::Attribute;
 use rustc_span::{DUMMY_SP, Ident, Span, Symbol, kw, sym};
@@ -484,7 +484,7 @@ impl<'a> TraitDef<'a> {
         match item {
             Annotatable::Item(item) => {
                 let is_packed = matches!(
-                    AttributeParser::parse_limited(cx.sess, &item.attrs, sym::repr, item.span, item.id),
+                    AttributeParser::parse_limited(cx.sess, &item.attrs, sym::repr, AttrTarget::Todo, item.span, item.id),
                     Some(Attribute::Parsed(AttributeKind::Repr(r))) if r.iter().any(|(x, _)| matches!(x, ReprPacked(..)))
                 );
 

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -1,6 +1,6 @@
 use rustc_abi::ExternAbi;
 use rustc_attr_data_structures::{AttributeKind, ReprAttr};
-use rustc_attr_parsing::AttributeParser;
+use rustc_attr_parsing::{AttrTarget, AttributeParser};
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::intravisit::FnKind;
 use rustc_hir::{AttrArgs, AttrItem, Attribute, GenericParamKind, PatExprKind, PatKind};
@@ -164,7 +164,7 @@ impl NonCamelCaseTypes {
 impl EarlyLintPass for NonCamelCaseTypes {
     fn check_item(&mut self, cx: &EarlyContext<'_>, it: &ast::Item) {
         let has_repr_c = matches!(
-            AttributeParser::parse_limited(cx.sess(), &it.attrs, sym::repr, it.span, it.id),
+            AttributeParser::parse_limited(cx.sess(), &it.attrs,  sym::repr, AttrTarget::Todo, it.span, it.id),
             Some(Attribute::Parsed(AttributeKind::Repr(r))) if r.iter().any(|(r, _)| r == &ReprAttr::ReprC)
         );
 

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -3,7 +3,7 @@ use std::mem;
 use rustc_ast::visit::FnKind;
 use rustc_ast::*;
 use rustc_ast_pretty::pprust;
-use rustc_attr_parsing::{AttributeParser, OmitDoc};
+use rustc_attr_parsing::{AttrTarget, AttributeParser, OmitDoc};
 use rustc_expand::expand::AstFragment;
 use rustc_hir as hir;
 use rustc_hir::def::{CtorKind, CtorOf, DefKind};
@@ -135,6 +135,7 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
                 );
                 let attrs = parser.parse_attribute_list(
                     &i.attrs,
+                    AttrTarget::Todo,
                     i.span,
                     i.id,
                     OmitDoc::Skip,

--- a/tests/ui/woops.rs
+++ b/tests/ui/woops.rs
@@ -1,0 +1,5 @@
+#![crate_type = "lib"]
+#![feature(rustc_attrs)]
+
+#[rustc_as_ptr] //~ERROR
+pub struct X;

--- a/tests/ui/woops.stderr
+++ b/tests/ui/woops.stderr
@@ -1,0 +1,8 @@
+error: rustc_as_ptr must be applied to a function or method (rejected during attr parsing)
+  --> $DIR/woops.rs:4:1
+   |
+LL | #[rustc_as_ptr]
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/woops.stderr
+++ b/tests/ui/woops.stderr
@@ -1,4 +1,4 @@
-error: rustc_as_ptr must be applied to a function or method (rejected during attr parsing)
+error: `#[rustc_as_ptr]` is not valid at that position. It is only allowed in ["function", "method"]
   --> $DIR/woops.rs:4:1
    |
 LL | #[rustc_as_ptr]


### PR DESCRIPTION
The first commit creates `AttrTarget`. This passes down an enum to the attribute parsers so that they can tell what item they're on. This will allow us to move a lot of validation code from various passes directly into the parsers.

The second commit adds an associated const, so that we can do position checking similar to how duplicate attributes are handled with a const of `AttributeOrder`. You just declare it, it does the rest.  We can do more than the `allowed!` macro; possibilities are `unstable!`, `future_error!` etc. 

For more complicated relationships between the attribute and its item, like the #[naked] attribute and function abi, or diagnostic::on_unimplemented and the item's generic parameters, you cannot use that associated const; you still need to look at `cx.target`. The vast majority of attributes won't need to do that.

Random thoughts:
- `rustc_hir::Target` is a similar but fieldless enum. However it is quite overloaded, it is used for lang items a lot for example, so reusing it would be quite a painful refactor. It's also sort of lacking, having no distinction between a trait method and an impl method for example.
- What kind of data do we want to put there? `rustc_ast` types is the easiest, `rustc_hir` types would be more useful but complicated
- - we'd need to commit to parsing hir items before hir attributes but some lowering steps like `lower_maybe_coroutine_body` need to have the attributes parsed, and switching lowering order here might be ugly, impractical or impossible.
- - giving people access to some hir while lowering other hir might be confusing and error prone? It just feels like a bad idea to me.
- What data should be in the enum? Do we want a "Nothing initially, just add it when you need it" approach.
- Where do we put `AttrTarget`? Putting it outside rustc_ast and rustc_hir has the advantage that it's obviously not some kind of syntax, element or data type etc.
- We can't do 
 ```rust
 pub enum AttrTarget<'ast> {
    Struct {
        struct_: &'ast ast::Struct,
    },
    ..
  }
  ``` 
  Because `ast::Struct` doesn't exist - it's just a bunch of fields in `ItemKind`. Do we want to refactor that into a proper ast type, just keep passing fields, or something else?